### PR TITLE
JWT Signature Verification; Nonce Support, and setting 'provider' in profile

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -4,12 +4,28 @@ const querystring = require('querystring');
 const passport = require('passport-strategy');
 const OAuth2 = require('oauth').OAuth2;
 const jwt = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
 
 const NullStateStore = require('./state/null');
 const SessionStateStore = require('./state/session');
 const AuthorizationError = require('./errors/authorizationerror');
 const TokenError = require('./errors/tokenerror');
 const InternalOAuthError = require('./errors/internaloautherror');
+
+const jwks_client = jwksClient({
+    strictSsl: true,
+    rateLimit: true,
+    cache: true,
+    cacheMaxEntries: 100,
+    cacheMaxAge: 1000 * 60 * 60 * 24,
+    jwksUri: 'https://appleid.apple.com/auth/keys'
+});
+
+const getAppleJWKSKey = (header, callback) => {
+    jwks_client.getSigningKey(header.kid, (err, key) => {
+        callback(err, key && (key.publicKey || key.rsaPublicKey));
+    });
+};
 
 class AppleStrategy extends passport.Strategy {
     /**
@@ -95,67 +111,55 @@ class AppleStrategy extends passport.Strategy {
                         const idToken = params['id_token'];
                         if (!idToken) return this.error(new Error('ID Token not present in token response'));
 
-                        const idTokenSegments = idToken.split('.');
-                        let jwtClaims;
+                        const verifyOpts = {
+                            audience: this._clientID,
+                            issuer: 'https://appleid.apple.com',
+                            algorithms: ['RS256']
+                        };
+                        // TODO: nonce and nonce_supported claims... we should have set a nonce, and if nonce_supported is in the response, we should verify it
+                        jwt.verify(idToken, getAppleJWKSKey, verifyOpts, (err, jwtClaims) => {
+                            if (err) {
+                                return this.error(err);
+                            }
 
-                        try {
-                            const jwtClaimsStr = Buffer.from(idTokenSegments[1], 'base64').toString();
-                            jwtClaims = JSON.parse(jwtClaimsStr);
-                        } catch (ex) {
-                            return this.error(ex);
-                        }
+                            const profile = { id: jwtClaims.sub, provider: 'apple' };
 
-                        const missing = ['iss', 'sub', 'aud', 'exp', 'iat'].filter((param) => !jwtClaims[param]);
-                        if (missing.length)
-                            return this.error(
-                                new Error('id token is missing required parameter(s) - ' + missing.join(', '))
-                            );
+                            if (jwtClaims.email) profile.email = jwtClaims.email;
 
-                        if (jwtClaims.iss !== 'https://appleid.apple.com')
-                            return this.error(new Error('id token not issued by correct OpenID provider'));
+                            if (jwtClaims.email_verified) profile.emailVerified = jwtClaims.email_verified === 'true';
 
-                        if (jwtClaims.aud !== this._clientID)
-                            return this.error(new Error('aud parameter does not include this client'));
-
-                        if (jwtClaims.exp < Date.now() / 1000) return this.error(new Error('id token has expired'));
-
-                        const profile = { id: jwtClaims.sub };
-
-                        if (jwtClaims.email) profile.email = jwtClaims.email;
-
-                        if (jwtClaims.email_verified) profile.emailVerified = jwtClaims.email_verified === 'true';
-
-                        if (req.body.user) {
-                            if (typeof req.body.user === 'object' && req.body.user.name) {
-                                profile.name = req.body.user.name;
-                            } else {
-                                try {
-                                    const user = JSON.parse(req.body.user);
-                                    if (user && user.name) profile.name = user.name;
-                                } catch (ex) {
-                                    return this.error(ex);
+                            if (req.body.user) {
+                                if (typeof req.body.user === 'object' && req.body.user.name) {
+                                    profile.name = req.body.user.name;
+                                } else {
+                                    try {
+                                        const user = JSON.parse(req.body.user);
+                                        if (user && user.name) profile.name = user.name;
+                                    } catch (ex) {
+                                        return this.error(ex);
+                                    }
                                 }
                             }
-                        }
 
-                        const verified = (err, user, info) => {
-                            if (err) return this.error(err);
-                            if (!user) return this.fail(info);
+                            const verified = (err, user, info) => {
+                                if (err) return this.error(err);
+                                if (!user) return this.fail(info);
 
-                            info = info || {};
-                            if (state) info.state = state;
-                            this.success(user, info);
-                        };
+                                info = info || {};
+                                if (state) info.state = state;
+                                this.success(user, info);
+                            };
 
-                        try {
-                            if (this._passReqToCallback) {
-                                this._verify(req, accessToken, refreshToken, profile, verified);
-                            } else {
-                                this._verify(accessToken, refreshToken, profile, verified);
+                            try {
+                                if (this._passReqToCallback) {
+                                    this._verify(req, accessToken, refreshToken, profile, verified);
+                                } else {
+                                    this._verify(accessToken, refreshToken, profile, verified);
+                                }
+                            } catch (ex) {
+                                return this.error(ex);
                             }
-                        } catch (ex) {
-                            return this.error(ex);
-                        }
+                        });
                     });
                 });
             } catch (ex) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -69,6 +69,7 @@ class AppleStrategy extends passport.Strategy {
         this._scope = options.scope;
         this._sessionKey = options.sessionKey || 'apple:' + url.parse(this._authorizationURL).hostname;
         this._clientSecretExpiry = options.clientSecretExpiry || '5 minutes';
+        this._verifyNonce = options.verifyNonce;
 
         if (options.state) {
             this._stateStore = new SessionStateStore({ key: this._sessionKey });
@@ -77,6 +78,14 @@ class AppleStrategy extends passport.Strategy {
         }
 
         this._passReqToCallback = options.passReqToCallback;
+    }
+
+    verifyNonce(req, nonce_supported, nonce, callback) {
+        if (this._verifyNonce && nonce_supported) {
+            return this._verifyNonce(req, nonce, callback);
+        } else {
+            return callback(null, true);
+        }
     }
 
     /**
@@ -122,49 +131,57 @@ class AppleStrategy extends passport.Strategy {
                             issuer: 'https://appleid.apple.com',
                             algorithms: ['RS256']
                         };
-                        // TODO: nonce and nonce_supported claims... we should have set a nonce, and if nonce_supported is in the response, we should verify it
                         jwt.verify(idToken, getAppleJWKSKey, verifyOpts, (err, jwtClaims) => {
                             if (err) {
                                 return this.error(err);
                             }
 
-                            const profile = { id: jwtClaims.sub, provider: 'apple' };
+                            this.verifyNonce(req, jwtClaims.nonce_supported, jwtClaims.nonce, (err, ok) => {
+                                if (err) return this.error(err);
+                                if (!ok) return this.fail({ message: 'invalid nonce' });
 
-                            if (jwtClaims.email) profile.email = jwtClaims.email;
+                                const profile = { id: jwtClaims.sub, provider: 'apple' };
 
-                            if (jwtClaims.email_verified) profile.emailVerified = jwtClaims.email_verified === 'true';
+                                if (jwtClaims.email) {
+                                    profile.email = jwtClaims.email;
+                                }
 
-                            if (req.body.user) {
-                                if (typeof req.body.user === 'object' && req.body.user.name) {
-                                    profile.name = req.body.user.name;
-                                } else {
-                                    try {
-                                        const user = JSON.parse(req.body.user);
-                                        if (user && user.name) profile.name = user.name;
-                                    } catch (ex) {
-                                        return this.error(ex);
+                                if (jwtClaims.email_verified) {
+                                    profile.emailVerified = jwtClaims.email_verified === 'true';
+                                }
+
+                                if (req.body.user) {
+                                    if (typeof req.body.user === 'object' && req.body.user.name) {
+                                        profile.name = req.body.user.name;
+                                    } else {
+                                        try {
+                                            const user = JSON.parse(req.body.user);
+                                            if (user && user.name) profile.name = user.name;
+                                        } catch (ex) {
+                                            return this.error(ex);
+                                        }
                                     }
                                 }
-                            }
 
-                            const verified = (err, user, info) => {
-                                if (err) return this.error(err);
-                                if (!user) return this.fail(info);
+                                const verified = (err, user, info) => {
+                                    if (err) return this.error(err);
+                                    if (!user) return this.fail(info);
 
-                                info = info || {};
-                                if (state) info.state = state;
-                                this.success(user, info);
-                            };
+                                    info = info || {};
+                                    if (state) info.state = state;
+                                    this.success(user, info);
+                                };
 
-                            try {
-                                if (this._passReqToCallback) {
-                                    this._verify(req, accessToken, refreshToken, profile, verified);
-                                } else {
-                                    this._verify(accessToken, refreshToken, profile, verified);
+                                try {
+                                    if (this._passReqToCallback) {
+                                        this._verify(req, accessToken, refreshToken, profile, verified);
+                                    } else {
+                                        this._verify(accessToken, refreshToken, profile, verified);
+                                    }
+                                } catch (ex) {
+                                    return this.error(ex);
                                 }
-                            } catch (ex) {
-                                return this.error(ex);
-                            }
+                            });
                         });
                     });
                 });
@@ -181,6 +198,10 @@ class AppleStrategy extends passport.Strategy {
             let scope = options.scope || this._scope;
             if (scope) {
                 params.scope = scope.join(' ');
+            }
+
+            if (options.nonce) {
+                params.nonce = options.nonce;
             }
 
             const state = options.state;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,6 +27,11 @@ const getAppleJWKSKey = (header, callback) => {
     });
 };
 
+// the client secret for a given key is a signed JWT which is allowed to live
+// for a relatively long time, so cache and re-use these to avoid unnecessary
+// signature operations:
+const clientSecretCache = new Map();
+
 class AppleStrategy extends passport.Strategy {
     /**
      * @param {object} options
@@ -63,6 +68,7 @@ class AppleStrategy extends passport.Strategy {
         this._callbackURL = options.callbackURL;
         this._scope = options.scope;
         this._sessionKey = options.sessionKey || 'apple:' + url.parse(this._authorizationURL).hostname;
+        this._clientSecretExpiry = options.clientSecretExpiry || '5 minutes';
 
         if (options.state) {
             this._stateStore = new SessionStateStore({ key: this._sessionKey });
@@ -205,19 +211,33 @@ class AppleStrategy extends passport.Strategy {
     }
 
     /**
+     * @returns {jwt|string} signed jwt client secret
+     */
+    _getClientSecret() {
+        // if our current secret has expired (with a few seconds grace), or
+        // hasn't been generated yet, regenerate it:
+        const existing = clientSecretCache.get(this._keyID);
+        if (!existing || jwt.decode(existing).exp < Date.now() / 1000 + 5) {
+            clientSecretCache.set(
+                this._keyID,
+                jwt.sign({}, this._key, {
+                    algorithm: 'ES256',
+                    keyid: this._keyID,
+                    expiresIn: this._clientSecretExpiry,
+                    issuer: this._teamID,
+                    audience: 'https://appleid.apple.com',
+                    subject: this._clientID
+                })
+            );
+        }
+        return clientSecretCache.get(this._keyID);
+    }
+
+    /**
      * @returns {oauth2.OAuth2}
      */
     _getOAuth2Client() {
-        const clientSecret = jwt.sign({}, this._key, {
-            algorithm: 'ES256',
-            keyid: this._keyID,
-            expiresIn: '5 minutes',
-            issuer: this._teamID,
-            audience: 'https://appleid.apple.com',
-            subject: this._clientID
-        });
-
-        return new OAuth2(this._clientID, clientSecret, '', this._authorizationURL, this._tokenURL);
+        return new OAuth2(this._clientID, this._getClientSecret(), '', this._authorizationURL, this._tokenURL);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
+    "jwks-rsa": "^1.8.0",
     "oauth": "^0.9.15",
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.3"


### PR DESCRIPTION
 * added verification of the signature of the JWT response from apple, with keys fetched by the `jwks-rsa` library. This also simplifies parsing and checking of the other JWT claims, which is now all handled by `jsonwebtoken`.

 * Added a pair of options to the constructor and authenticate so that users can supply a nonce for each authenticate call, and verify it. (It would be nice to do this internally, but I'm not sure how to portably handle cases where the nonce may be set by a different server than the one which verifies it: maybe assuming req.session is correctly synced and storing it there would be OK?)

 * set provider=apple in the profile, to be consistent with the passport API. (the other fields in the profile are also not following the recommended format, for example `profile.emails` should be set in the standard form `[{ type: 'home', value: email }]`, and the name should be under `givenName` `familyName` etc.: http://www.passportjs.org/docs/profile/ but changing these would have been a disruptive change so best handled separately)

 * Cache and re-use the client Secret. In theory this can have an expiry of [up to 6 months](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens).

