### PR TITLE
Include clientID in client secret cache key

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -240,10 +240,11 @@ class AppleStrategy extends passport.Strategy {
     _getClientSecret() {
         // if our current secret has expired (with a few seconds grace), or
         // hasn't been generated yet, regenerate it:
-        const existing = clientSecretCache.get(this._keyID);
+        const cacheKey = `${this._keyID}-${this._clientID}`;
+        const existing = clientSecretCache.get(cacheKey);
         if (!existing || jwt.decode(existing).exp < Date.now() / 1000 + 5) {
             clientSecretCache.set(
-                this._keyID,
+                cacheKey,
                 jwt.sign({}, this._key, {
                     algorithm: 'ES256',
                     keyid: this._keyID,
@@ -254,7 +255,7 @@ class AppleStrategy extends passport.Strategy {
                 })
             );
         }
-        return clientSecretCache.get(this._keyID);
+        return clientSecretCache.get(cacheKey);
     }
 
     /**


### PR DESCRIPTION
It's possible to use multiple `clientIDs` while using a single key(ID). Currently `AppleStrategy` uses the keyID to cache the OAuth secret for the duration of its lifetime. This means that when using multiple `AppleStrategy` instances with different `clientIDs` and the same `keyID` both instances will use the same secret, which means one instance will be using an invalid secret (as it contains the other instance's `clientID`). Meaning authentication attempts using one instance will always fail, though which one of the two can switch.

Here's a quick change that simply includes the `clientID` in the cache key for the client secret, fixing the issue. Happy to make changes if necessary.