### PR TITLE
Fix: include missing folders in the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "appleid"
   ],
   "files": [
-    "./lib/*"
+    "./lib/**/*"
   ],
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
This should fix my issue reported here https://github.com/nicokaiser/passport-apple/issues/82